### PR TITLE
Add check on really Quip reply form post before checking fields on errors

### DIFF
--- a/core/components/quip/controllers/web/ThreadReply.php
+++ b/core/components/quip/controllers/web/ThreadReply.php
@@ -240,6 +240,11 @@ class QuipThreadReplyController extends QuipController {
             $fields[$k] = str_replace(array('[',']'),array('&#91;','&#93;'),$v);
         }
 
+        if(empty($fields[$this->getProperty('postAction','quip-post')]) &&
+            empty($fields[$this->getProperty('previewAction','quip-preview')])) {
+            return;
+        }
+
         $fields['name'] = strip_tags($fields['name']);
         $fields['email'] = strip_tags($fields['email']);
         $fields['website'] = strip_tags($fields['website']);

--- a/core/components/quip/test/Tests/Core/QuipReplyTest.php
+++ b/core/components/quip/test/Tests/Core/QuipReplyTest.php
@@ -158,7 +158,7 @@ class QuipReplyTest extends QuipTestCase {
         $this->controller->setProperty('recaptcha',$recaptcha);
         $this->controller->setProperty('recaptchaTheme',$recaptchaTheme);
         if ($userHasAuth) {
-            $this->controller->hasAuth = true;
+            $this->controller->modx->user->addSessionContext('web');
         }
 
         $success = $this->controller->loadReCaptcha();

--- a/core/components/quip/test/Tests/Core/QuipTest.php
+++ b/core/components/quip/test/Tests/Core/QuipTest.php
@@ -199,7 +199,7 @@ class QuipTest extends QuipTestCase {
      */
     public function providerPreparePaginationIds() {
         return array(
-            array(10),
+            array(10,'quipComment','rank','ASC'),
         );
     }
 
@@ -239,8 +239,8 @@ class QuipTest extends QuipTestCase {
      */
     public function providerGetComments() {
         return array(
-            array(true),
-            array(false,1),
+            array(true,0,'rank','quipComment','ASC'),
+            array(false,1,'rank','quipComment','ASC'),
         );
     }
 


### PR DESCRIPTION
- Add some precheck if it's Quip form send, cause sometimes there is 2 or more
  forms on one page and Quip reports empty fields even it's form not really send.
- Fix tests on load captcha with user login. Old test used deprecated parameter
- Fix tests with empty provider data: sometimes using NULL as default value
  instead of default method parameter.

Signed-off-by: Egor Bolgov egor.b@fabricasaitov.ru
