### PR TITLE
Reply comments listing FIX

### DIFF
--- a/core/components/quip/model/quip/quipcomment.class.php
+++ b/core/components/quip/model/quip/quipcomment.class.php
@@ -64,7 +64,7 @@ class quipComment extends xPDOSimpleObject {
         }
         if (!empty($parent)) {
             $c->where(array(
-                'Descendants.ancestor' => $parent,
+                'Ancestors.descendant' => $parent,
             ));
         }
         $total = $modx->getCount('quipComment',$c);


### PR DESCRIPTION
In XPDO "where" clause "Descendants.ancestor" changed into "Ancestors.descendant" (This bug caused that if you were replying to some post, displayed post parents did not contained data.)
